### PR TITLE
Save images with transparency and several other improvements

### DIFF
--- a/BitmapGenerator/BitmapGenerator.py
+++ b/BitmapGenerator/BitmapGenerator.py
@@ -18,7 +18,7 @@ class BitmapGenerator(ScriptedLoadableModule):
     self.parent.title = "Bitmap Generator"
     self.parent.categories = ["SlicerFab"]
     self.parent.dependencies = []
-    self.parent.contributors = ["Steve Pieper (Isomics, Inc.), Steve Keating (MIT), Ahmed Hosny (Harvard), James Weaver (Harvard)"] # replace with "Firstname Lastname (Organization)"
+    self.parent.contributors = ["Steve Pieper (Isomics, Inc.), Steve Keating (MIT), Ahmed Hosny (Harvard), James Weaver (Harvard)", Andras Lasso (Queens)] # replace with "Firstname Lastname (Organization)"
     self.parent.helpText = """
     Generate bitmap images for 3D printers that use images instead of surface models.
     """


### PR DESCRIPTION
New features:
- images are saved with transparency (alpha channel)
- layer thickness can be configured on GUI
- image generation can be cancelled
- cleaned up rendering view management (instead of hijacking an existing view node, a new view node is created)
- turn off shading (lighting direction, reflections, etc. should not be baked into the exported images)