### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,12 @@ project(SlicerFab)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "http://github.com/SlicerFab/SlicerFab")
+set(EXTENSION_HOMEPAGE "https://github.com/SlicerFab/SlicerFab")
 set(EXTENSION_CATEGORY "Printing")
 set(EXTENSION_CONTRIBUTORS "Steve Pieper (Isomics, Inc.), Ahmed Hosney (Harvard Wyss), James Weaver (Harvard Wyss), Steve Keating (MIT Media Lab)")
 set(EXTENSION_DESCRIPTION "Tools for 3D object fabrication.")
-set(EXTENSION_ICONURL "https://github.com/SlicerFab/SlicerFab/raw/master/slices.png")
-set(EXTENSION_SCREENSHOTURLS "https://github.com/SlicerFab/SlicerFab/raw/master/rendering.png")
+set(EXTENSION_ICONURL "https://raw.githubusercontent.com/SlicerFab/SlicerFab/master/slices.png")
+set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/SlicerFab/SlicerFab/master/rendering.png")
 
 #-----------------------------------------------------------------------------
 # Extension dependencies


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.